### PR TITLE
Lazy GitHub api calls + building only merge branches

### DIFF
--- a/src/main/java/in/ashwanthkumar/gocd/github/GHUtils.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/GHUtils.java
@@ -1,5 +1,7 @@
 package in.ashwanthkumar.gocd.github;
 
+import org.eclipse.jgit.lib.Ref;
+
 public class GHUtils {
     public static String parseGithubUrl(String url) {
         String urlInLowerCase = url.toLowerCase();
@@ -21,4 +23,11 @@ public class GHUtils {
     public static int prIdFrom(String diffUrl) {
         return Integer.parseInt(diffUrl.substring(diffUrl.indexOf("/pull/") + 6, diffUrl.length() - 5));
     }
+
+    public static int pullRequestIdFromRef(Ref prRef) {
+        // generally of the form refs/gh-merge/remotes/origin/3
+        String idInString = prRef.getName().split("/")[4];
+        return Integer.valueOf(idInString);
+    }
+
 }

--- a/src/main/java/in/ashwanthkumar/gocd/github/GitConstants.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/GitConstants.java
@@ -1,0 +1,7 @@
+package in.ashwanthkumar.gocd.github;
+
+public class GitConstants {
+
+    public static final String PR_FETCH_REFSPEC = "+refs/pull/*/merge:refs/gh-merge/remotes/origin/*";
+    public static final String PR_MERGE_PREFIX = "refs/gh-merge/remotes/origin";
+}

--- a/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
@@ -227,10 +227,6 @@ public class GitHubPRBuildPlugin implements GoPlugin {
         }
     }
 
-    private GHPullRequest pullRequestFrom(String url, int currentPullRequestID) throws IOException {
-        return GitHub.connect().getRepository(GHUtils.parseGithubUrl(url)).getPullRequest(currentPullRequestID);
-    }
-
     private GoPluginApiResponse handleCheckout(GoPluginApiRequest goPluginApiRequest) {
         Map<String, String> configuration = keyValuePairs(goPluginApiRequest, "scm-configuration");
         String url = configuration.get("url");
@@ -257,6 +253,10 @@ public class GitHubPRBuildPlugin implements GoPlugin {
             LOGGER.warn("checkout: ", t);
             return renderJSON(INTERNAL_ERROR_RESPONSE_CODE, t.getMessage());
         }
+    }
+
+    private GHPullRequest pullRequestFrom(String url, int currentPullRequestID) throws IOException {
+        return GitHub.connect().getRepository(GHUtils.parseGithubUrl(url)).getPullRequest(currentPullRequestID);
     }
 
     private Function<GHPullRequest, PullRequestStatus> transformGHPullRequestToPullRequestStatus(final String mergedSHA) {

--- a/src/main/java/in/ashwanthkumar/gocd/github/JGitHelper.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/JGitHelper.java
@@ -84,7 +84,7 @@ public class JGitHelper {
                     return new RefSpec(input);
                 }
             });
-            FetchCommand fetch = git.fetch().setRefSpecs(refSpecs);
+            FetchCommand fetch = git.fetch().setRemoveDeletedRefs(true).setRefSpecs(refSpecs);
             if (url.startsWith("http") || url.startsWith("https")) {
                 // TODO - if url is http/https - set credentials
             }

--- a/src/main/java/in/ashwanthkumar/gocd/github/model/MergeRefs.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/model/MergeRefs.java
@@ -1,0 +1,32 @@
+package in.ashwanthkumar.gocd.github.model;
+
+import in.ashwanthkumar.utils.collections.Iterables;
+import in.ashwanthkumar.utils.lang.option.Option;
+import org.eclipse.jgit.lib.Ref;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MergeRefs {
+    private List<Ref> mergeRefs = new ArrayList<Ref>();
+
+    public MergeRefs(List<Ref> mergeRefs) {
+        this.mergeRefs = mergeRefs;
+    }
+
+    public boolean isEmpty() {
+        return mergeRefs.isEmpty();
+    }
+
+    public boolean nonEmpty() {
+        return !isEmpty();
+    }
+
+    public Ref head() {
+        return Iterables.head(mergeRefs);
+    }
+
+    public Option<Ref> headOption() {
+        return Iterables.headOption(mergeRefs);
+    }
+}

--- a/src/main/java/in/ashwanthkumar/gocd/github/model/MergeRefs.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/model/MergeRefs.java
@@ -1,11 +1,15 @@
 package in.ashwanthkumar.gocd.github.model;
 
 import in.ashwanthkumar.utils.collections.Iterables;
+import in.ashwanthkumar.utils.collections.Lists;
+import in.ashwanthkumar.utils.func.Predicate;
 import in.ashwanthkumar.utils.lang.option.Option;
 import org.eclipse.jgit.lib.Ref;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static in.ashwanthkumar.gocd.github.GHUtils.pullRequestIdFromRef;
 
 public class MergeRefs {
     private List<Ref> mergeRefs = new ArrayList<Ref>();
@@ -28,5 +32,25 @@ public class MergeRefs {
 
     public Option<Ref> headOption() {
         return Iterables.headOption(mergeRefs);
+    }
+
+    public boolean hasPullRequest(final int pullRequestId) {
+        return Iterables.exists(mergeRefs, new Predicate<Ref>() {
+            @Override
+            public Boolean apply(Ref input) {
+                // ref pattern are of the form "refs/gh-merge/remotes/origin/3"
+                return input.getName().endsWith(String.valueOf(pullRequestId));
+            }
+        });
+    }
+
+    public Option<Ref> findNotProcessed(final PullRequests existingPullRequestsInfo) {
+        return Lists.find(mergeRefs, new Predicate<Ref>() {
+            @Override
+            public Boolean apply(Ref input) {
+                int pullRequestId = pullRequestIdFromRef(input);
+                return existingPullRequestsInfo.hasNotId(pullRequestId) || existingPullRequestsInfo.hasChanged(pullRequestId, input.getObjectId().name());
+            }
+        });
     }
 }

--- a/src/main/java/in/ashwanthkumar/gocd/github/model/PullRequestStatus.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/model/PullRequestStatus.java
@@ -1,13 +1,15 @@
 package in.ashwanthkumar.gocd.github.model;
 
+import in.ashwanthkumar.gocd.github.GitConstants;
 import in.ashwanthkumar.gocd.github.json.Exclude;
 
 public class PullRequestStatus {
     private int id;
-    private String ref;
     private String mergeRef;
+    // We use this while computing the revisions
     private String lastHead;
-    private boolean alreadyScheduled;
+    // We use this to find changes in a PR
+    private String mergeSHA;
     @Exclude
     private String prBranch;
     @Exclude
@@ -23,13 +25,12 @@ public class PullRequestStatus {
     @Exclude
     private String title;
 
-    public PullRequestStatus(int id, String headSHA, String prBranch, String toBranch, String url,
+    public PullRequestStatus(int id, String lastHead, String mergedSHA, String prBranch, String toBranch, String url,
                              String author, String authorEmail, String description, String title) {
         this.id = id;
-        this.ref = String.format("refs/pull/%d/head", getId());
-        this.mergeRef = String.format("refs/pull/%d/merge", getId());
-        this.lastHead = headSHA;
-        this.alreadyScheduled = false;
+        this.mergeRef = String.format("%s/%d", GitConstants.PR_MERGE_PREFIX , getId());
+        this.lastHead = lastHead;
+        this.mergeSHA = mergedSHA;
         this.prBranch = prBranch;
         this.toBranch = toBranch;
         this.url = url;
@@ -46,16 +47,8 @@ public class PullRequestStatus {
         return id;
     }
 
-    public String getRef() {
-        return ref;
-    }
-
     public String getLastHead() {
         return lastHead;
-    }
-
-    public boolean isAlreadyScheduled() {
-        return alreadyScheduled;
     }
 
     public String getPrBranch() {
@@ -86,18 +79,17 @@ public class PullRequestStatus {
         return title;
     }
 
-    public PullRequestStatus scheduled() {
-        this.alreadyScheduled = true;
-        return this;
-    }
-
     public String getMergeRef() {
         return mergeRef;
     }
 
+    public String getMergeSHA() {
+        return mergeSHA;
+    }
+
     public PullRequestStatus merge(PullRequestStatus newPRStatus) {
-        if (lastHead.equalsIgnoreCase(newPRStatus.getLastHead())) return copy().mergePRFields(newPRStatus);
-        else return new PullRequestStatus(id, newPRStatus.getLastHead(), newPRStatus.prBranch, newPRStatus.toBranch,
+        if (mergeSHA.equalsIgnoreCase(newPRStatus.getMergeSHA())) return copy().mergePRFields(newPRStatus);
+        else return new PullRequestStatus(id, lastHead, newPRStatus.mergeSHA, newPRStatus.prBranch, newPRStatus.toBranch,
                 newPRStatus.url, newPRStatus.author, newPRStatus.authorEmail, newPRStatus.description, newPRStatus.title);
     }
 
@@ -117,22 +109,23 @@ public class PullRequestStatus {
     }
 
     private PullRequestStatus copy() {
-        PullRequestStatus clone = new PullRequestStatus(id, lastHead, prBranch, toBranch, url, author, authorEmail, description, title);
-        if (isAlreadyScheduled()) clone.scheduled();
-        return clone;
+        return new PullRequestStatus(id, lastHead, mergeSHA, prBranch, toBranch, url, author, authorEmail, description, title);
     }
-
 
     @Override
     public String toString() {
         return "PullRequestStatus{" +
                 "id=" + id +
-                ", ref='" + ref + '\'' +
+                ", mergeRef='" + mergeRef + '\'' +
                 ", lastHead='" + lastHead + '\'' +
+                ", mergeSHA='" + mergeSHA + '\'' +
                 ", prBranch='" + prBranch + '\'' +
                 ", toBranch='" + toBranch + '\'' +
                 ", url='" + url + '\'' +
-                ", alreadyScheduled=" + alreadyScheduled +
+                ", author='" + author + '\'' +
+                ", authorEmail='" + authorEmail + '\'' +
+                ", description='" + description + '\'' +
+                ", title='" + title + '\'' +
                 '}';
     }
 
@@ -143,11 +136,15 @@ public class PullRequestStatus {
 
         PullRequestStatus that = (PullRequestStatus) o;
 
-        if (alreadyScheduled != that.alreadyScheduled) return false;
         if (id != that.id) return false;
+        if (author != null ? !author.equals(that.author) : that.author != null) return false;
+        if (authorEmail != null ? !authorEmail.equals(that.authorEmail) : that.authorEmail != null) return false;
+        if (description != null ? !description.equals(that.description) : that.description != null) return false;
         if (lastHead != null ? !lastHead.equals(that.lastHead) : that.lastHead != null) return false;
+        if (mergeRef != null ? !mergeRef.equals(that.mergeRef) : that.mergeRef != null) return false;
+        if (mergeSHA != null ? !mergeSHA.equals(that.mergeSHA) : that.mergeSHA != null) return false;
         if (prBranch != null ? !prBranch.equals(that.prBranch) : that.prBranch != null) return false;
-        if (ref != null ? !ref.equals(that.ref) : that.ref != null) return false;
+        if (title != null ? !title.equals(that.title) : that.title != null) return false;
         if (toBranch != null ? !toBranch.equals(that.toBranch) : that.toBranch != null) return false;
         if (url != null ? !url.equals(that.url) : that.url != null) return false;
 
@@ -157,12 +154,16 @@ public class PullRequestStatus {
     @Override
     public int hashCode() {
         int result = id;
-        result = 31 * result + (ref != null ? ref.hashCode() : 0);
+        result = 31 * result + (mergeRef != null ? mergeRef.hashCode() : 0);
         result = 31 * result + (lastHead != null ? lastHead.hashCode() : 0);
+        result = 31 * result + (mergeSHA != null ? mergeSHA.hashCode() : 0);
         result = 31 * result + (prBranch != null ? prBranch.hashCode() : 0);
         result = 31 * result + (toBranch != null ? toBranch.hashCode() : 0);
         result = 31 * result + (url != null ? url.hashCode() : 0);
-        result = 31 * result + (alreadyScheduled ? 1 : 0);
+        result = 31 * result + (author != null ? author.hashCode() : 0);
+        result = 31 * result + (authorEmail != null ? authorEmail.hashCode() : 0);
+        result = 31 * result + (description != null ? description.hashCode() : 0);
+        result = 31 * result + (title != null ? title.hashCode() : 0);
         return result;
     }
 }

--- a/src/main/java/in/ashwanthkumar/gocd/github/model/PullRequestStatus.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/model/PullRequestStatus.java
@@ -5,6 +5,7 @@ import in.ashwanthkumar.gocd.github.json.Exclude;
 public class PullRequestStatus {
     private int id;
     private String ref;
+    private String mergeRef;
     private String lastHead;
     private boolean alreadyScheduled;
     @Exclude
@@ -26,6 +27,7 @@ public class PullRequestStatus {
                              String author, String authorEmail, String description, String title) {
         this.id = id;
         this.ref = String.format("refs/pull/%d/head", getId());
+        this.mergeRef = String.format("refs/pull/%d/merge", getId());
         this.lastHead = headSHA;
         this.alreadyScheduled = false;
         this.prBranch = prBranch;
@@ -87,6 +89,10 @@ public class PullRequestStatus {
     public PullRequestStatus scheduled() {
         this.alreadyScheduled = true;
         return this;
+    }
+
+    public String getMergeRef() {
+        return mergeRef;
     }
 
     public PullRequestStatus merge(PullRequestStatus newPRStatus) {

--- a/src/main/java/in/ashwanthkumar/gocd/github/model/PullRequests.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/model/PullRequests.java
@@ -1,15 +1,19 @@
 package in.ashwanthkumar.gocd.github.model;
 
+import in.ashwanthkumar.utils.collections.Iterables;
 import in.ashwanthkumar.utils.collections.Lists;
 import in.ashwanthkumar.utils.func.Function;
 import in.ashwanthkumar.utils.func.Predicate;
 import in.ashwanthkumar.utils.lang.option.Option;
 import in.ashwanthkumar.utils.lang.tuple.Tuple2;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 import static in.ashwanthkumar.utils.collections.Iterables.toMap;
+import static in.ashwanthkumar.utils.collections.Lists.filter;
 import static in.ashwanthkumar.utils.collections.Lists.map;
 import static in.ashwanthkumar.utils.lang.option.Option.option;
 import static in.ashwanthkumar.utils.lang.tuple.Tuple2.tuple2;
@@ -31,37 +35,39 @@ public class PullRequests {
         return this;
     }
 
-    public PullRequests mergeWith(List<PullRequestStatus> newPRStatuses) {
+    public PullRequests mergeWith(PullRequestStatus currentPullRequest, final MergeRefs mergeRefs) {
         PullRequests newPullRequests = new PullRequests();
-        List<PullRequestStatus> updatedPRs = Lists.map(newPRStatuses, new Function<PullRequestStatus, PullRequestStatus>() {
-            @Override
-            public PullRequestStatus apply(PullRequestStatus newPRStatus) {
-                if (hasId(newPRStatus.getId())) return pullRequestStatuses.get(newPRStatus.getId()).merge(newPRStatus);
-                else return newPRStatus;
-            }
-        });
-        List<PullRequestStatus> purgedPRs = Lists.filter(updatedPRs, new Predicate<PullRequestStatus>() {
+        List<PullRequestStatus> prs = Lists.Nil();
+        if (hasId(currentPullRequest.getId())) {
+            prs.add(pullRequestStatuses.get(currentPullRequest.getId()).merge(currentPullRequest));
+        } else {
+            prs.add(currentPullRequest);
+        }
+
+        List<PullRequestStatus> purgedPRs = filter(concat(pullRequestStatuses.values(), prs), new Predicate<PullRequestStatus>() {
             @Override
             public Boolean apply(PullRequestStatus input) {
-                return pullRequestStatuses.containsKey(input.getId());
+                return mergeRefs.hasPullRequest(input.getId());
             }
         });
         newPullRequests.setPullRequestStatuses(purgedPRs);
         return newPullRequests;
     }
 
+    public <T> Iterable<T> concat(Collection<T> left, Collection<T> right) {
+        if(left == null) return right;
+        else if (right == null) return left;
+        else {
+            ArrayList<T> concat = new ArrayList<T>();
+            concat.addAll(left);
+            concat.addAll(right);
+            return concat;
+        }
+    }
+
     @Override
     public String toString() {
         return pullRequestStatuses.toString();
-    }
-
-    public Option<PullRequestStatus> nextNotProcessed() {
-        return Lists.find(pullRequestStatuses.values(), new Predicate<PullRequestStatus>() {
-            @Override
-            public Boolean apply(PullRequestStatus input) {
-                return !input.isAlreadyScheduled();
-            }
-        });
     }
 
     public Option<PullRequestStatus> findById(final int prId) {
@@ -72,15 +78,15 @@ public class PullRequests {
         return pullRequestStatuses.containsKey(prId);
     }
 
-    public PullRequestStatus get(int prId) {
-        return pullRequestStatuses.get(prId);
+    public boolean hasNotId(final int prId) {
+        return !hasId(prId);
     }
 
-    public void schedule(int prID) {
-        if (hasId(prID)) {
-            PullRequestStatus pullRequestStatus = get(prID);
-            pullRequestStatus.scheduled();
-            pullRequestStatuses.put(prID, pullRequestStatus);
-        }
+    public boolean hasChanged(int pullRequestId, String newMergedSHA) {
+        return hasId(pullRequestId) && !pullRequestStatuses.get(pullRequestId).getMergeSHA().equals(newMergedSHA);
+    }
+
+    public PullRequestStatus get(int prId) {
+        return pullRequestStatuses.get(prId);
     }
 }


### PR DESCRIPTION
- Reducing the amount of Github API calls we make
- We build only the PR's merge branch and not the PR's HEAD. Very similar how Travis CI does - http://docs.travis-ci.com/user/pull-requests/