### PR TITLE
Fix #17 - handle check connection when ~/.github file is not present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.61</version>
+            <version>1.68</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/in/ashwanthkumar/gocd/github/provider/github/GHUtils.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/provider/github/GHUtils.java
@@ -50,22 +50,6 @@ public class GHUtils {
         return Integer.parseInt(diffUrl.substring(diffUrl.indexOf("/pull/") + 6, diffUrl.length() - 5));
     }
 
-    public static int pullRequestIdFromRef(Ref prRef) {
-        // generally of the form refs/gh-merge/remotes/origin/3
-        String idInString = prRef.getName().split("/")[4];
-        return Integer.valueOf(idInString);
-    }
-
-    public static GitHub buildGithubFromPropertyFile() throws IOException {
-        Properties props = readPropertyFile();
-        GitHubBuilder self = new GitHubBuilder();
-        self.withOAuthToken(props.getProperty("oauth"), props.getProperty("login"));
-        self.withPassword(props.getProperty("login"), props.getProperty("password"));
-        // For github enterprise you need to suffix /api/v3
-        self.withEndpoint(props.getProperty("endpoint", GitHubProvider.PUBLIC_GITHUB_ENDPOINT));
-        return self.build();
-    }
-
     public static Properties readPropertyFile() throws IOException {
         File propertyFile = new File(System.getProperty("user.home"), ".github");
         Properties props = new Properties();

--- a/src/main/java/in/ashwanthkumar/gocd/github/provider/github/GitHubProvider.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/provider/github/GitHubProvider.java
@@ -6,6 +6,7 @@ import in.ashwanthkumar.gocd.github.provider.Provider;
 import in.ashwanthkumar.gocd.github.provider.github.model.PullRequestStatus;
 import in.ashwanthkumar.gocd.github.util.URLUtils;
 import in.ashwanthkumar.utils.func.Function;
+import in.ashwanthkumar.utils.lang.StringUtils;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
@@ -51,7 +52,7 @@ public class GitHubProvider implements Provider {
     @Override
     public void checkConnection(GitConfig gitConfig) {
         try {
-            GitHub.connect().getRepository(GHUtils.parseGithubUrl(gitConfig.getEffectiveUrl()));
+            loginWith(gitConfig).getRepository(GHUtils.parseGithubUrl(gitConfig.getEffectiveUrl()));
         } catch (Exception e) {
             throw new RuntimeException(String.format("check connection failed. %s", e.getMessage()), e);
         }
@@ -90,7 +91,7 @@ public class GitHubProvider implements Provider {
     }
 
     private GHPullRequest pullRequestFrom(GitConfig gitConfig, int currentPullRequestID) throws IOException {
-        return GHUtils.buildGithubFromPropertyFile()
+        return loginWith(gitConfig)
                 .getRepository(GHUtils.parseGithubUrl(gitConfig.getEffectiveUrl()))
                 .getPullRequest(currentPullRequestID);
     }
@@ -110,5 +111,14 @@ public class GitHubProvider implements Provider {
                 }
             }
         };
+    }
+
+    private GitHub loginWith(GitConfig gitConfig) throws IOException {
+        if(hasCredentials(gitConfig)) return GitHub.connectUsingPassword(gitConfig.getUsername(), gitConfig.getPassword());
+        else return GitHub.connect();
+    }
+
+    private boolean hasCredentials(GitConfig gitConfig) {
+        return StringUtils.isNotEmpty(gitConfig.getUsername()) && StringUtils.isNotEmpty(gitConfig.getPassword());
     }
 }


### PR DESCRIPTION
Upgrading the github-api to 1.68 that contains my PR for reading endpoint
as well from ~/.github file. We now create a Github instance from the gitConfig
if present else fallback to ~/.github.