### PR TITLE
Fixes #52 - Moving from jGit/git cmd identification to just git cmd

### DIFF
--- a/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
@@ -157,7 +157,7 @@ public class GitHubPRBuildPlugin implements GoPlugin {
         LOGGER.info(String.format("Flyweight: %s", flyweightFolder));
 
         try {
-            GitHelper git = HelperFactory.git(gitConfig, new File(flyweightFolder));
+            GitHelper git = HelperFactory.gitCmd(gitConfig, new File(flyweightFolder));
             git.cloneOrFetch(provider.getRefSpec());
             Map<String, String> branchToRevisionMap = git.getBranchToRevisionMap(provider.getRefPattern());
             Revision revision = git.getLatestRevision();
@@ -186,7 +186,7 @@ public class GitHubPRBuildPlugin implements GoPlugin {
         LOGGER.debug(String.format("Fetching latest for: %s", gitConfig.getUrl()));
 
         try {
-            GitHelper git = HelperFactory.git(gitConfig, new File(flyweightFolder));
+            GitHelper git = HelperFactory.gitCmd(gitConfig, new File(flyweightFolder));
             git.cloneOrFetch(provider.getRefSpec());
             Map<String, String> newBranchToRevisionMap = git.getBranchToRevisionMap(provider.getRefPattern());
 
@@ -252,7 +252,7 @@ public class GitHubPRBuildPlugin implements GoPlugin {
         LOGGER.info(String.format("destination: %s. commit: %s", destinationFolder, revision));
 
         try {
-            GitHelper git = HelperFactory.git(gitConfig, new File(destinationFolder));
+            GitHelper git = HelperFactory.gitCmd(gitConfig, new File(destinationFolder));
             git.cloneOrFetch(provider.getRefSpec());
             git.resetHard(revision);
 

--- a/src/main/java/in/ashwanthkumar/gocd/github/provider/gerrit/GerritProvider.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/provider/gerrit/GerritProvider.java
@@ -27,7 +27,7 @@ public class GerritProvider implements Provider {
 
     @Override
     public void checkConnection(GitConfig gitConfig) {
-        HelperFactory.git(gitConfig, null).checkConnection();
+        HelperFactory.gitCmd(gitConfig, null).checkConnection();
     }
 
     @Override

--- a/src/main/java/in/ashwanthkumar/gocd/github/provider/git/GitProvider.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/provider/git/GitProvider.java
@@ -31,7 +31,7 @@ public class GitProvider implements Provider {
 
     @Override
     public void checkConnection(GitConfig gitConfig) {
-        HelperFactory.git(gitConfig, null).checkConnection();
+        HelperFactory.gitCmd(gitConfig, null).checkConnection();
     }
 
     @Override

--- a/src/main/java/in/ashwanthkumar/gocd/github/provider/stash/StashProvider.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/provider/stash/StashProvider.java
@@ -27,7 +27,7 @@ public class StashProvider implements Provider {
 
     @Override
     public void checkConnection(GitConfig gitConfig) {
-        HelperFactory.git(gitConfig, null).checkConnection();
+        HelperFactory.gitCmd(gitConfig, null).checkConnection();
     }
 
     @Override


### PR DESCRIPTION
@srinivasupadhya If you could have a quick look at this, we can merge this and I would make a 1.2.1 release to test #49. 