### PR TITLE
Fallback to detecting latest revision if revisions-since call fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>in.ashwanthkumar</groupId>
     <artifactId>gocd-github-pr-material</artifactId>
-    <version>1.3.4</version>
+    <version>1.3.5</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/GitHubPRBuildPlugin.java
@@ -311,7 +311,12 @@ public class GitHubPRBuildPlugin implements GoPlugin {
                     String latestSHA = newerRevisions.get(branch);
                     if(StringUtils.isNotEmpty(lastKnownSHA)) {
                         git.resetHard(latestSHA);
-                        List<Revision> allRevisionsSince = git.getRevisionsSince(lastKnownSHA);
+                        List<Revision> allRevisionsSince;
+                        try {
+                            allRevisionsSince = git.getRevisionsSince(lastKnownSHA);
+                        } catch (Exception e) {
+                            allRevisionsSince = Collections.singletonList(git.getLatestRevision());
+                        }
                         List<Map<String, Object>> changesSinceLastCommit = Lists.map(allRevisionsSince, new Function<Revision, Map<String, Object>>() {
                             @Override
                             public Map<String, Object> apply(Revision revision) {


### PR DESCRIPTION
This usually happens when an attempt is made to force-push, and in the
meanwhile, the flyweight folder is deleted. The plugin tends to perform
a `git log last-commit..HEAD` and the `last-commit` is no longer in the
git object database, thereby rendering the plugin useless.

A workaround is to ask that the old commit be force-pushed (hopefully
whoever pushed the old commit still has it in their reflog)