### PR TITLE
Prevent autocomplete on username & password fields

### DIFF
--- a/src/main/resources/views/scm.template.branch.filter.html
+++ b/src/main/resources/views/scm.template.branch.filter.html
@@ -5,12 +5,12 @@
 </div>
 <div class="form_item_block">
     <label>Username:</label>
-    <input type="text" ng-model="username" ng-required="false"/>
+    <input type="text" autocomplete="new-password" ng-model="username" ng-required="false"/>
     <span class="form_error" ng-show="GOINPUTNAME[username].$error.server">{{ GOINPUTNAME[username].$error.server }}</span>
 </div>
 <div class="form_item_block">
     <label>Password:</label>
-    <input type="password" ng-model="password" ng-required="false"/>
+    <input type="password" autocomplete="new-password" ng-model="password" ng-required="false"/>
     <span class="form_error" ng-show="GOINPUTNAME[password].$error.server">{{ GOINPUTNAME[password].$error.server }}</span>
 </div>
 <div class="form_item_block">

--- a/src/main/resources/views/scm.template.html
+++ b/src/main/resources/views/scm.template.html
@@ -5,12 +5,12 @@
 </div>
 <div class="form_item_block">
     <label>Username:</label>
-    <input type="text" ng-model="username" ng-required="false"/>
+    <input type="text" autocomplete="new-password" ng-model="username" ng-required="false"/>
     <span class="form_error" ng-show="GOINPUTNAME[username].$error.server">{{ GOINPUTNAME[username].$error.server }}</span>
 </div>
 <div class="form_item_block">
     <label>Password:</label>
-    <input type="password" ng-model="password" ng-required="false"/>
+    <input type="password" autocomplete="new-password" ng-model="password" ng-required="false"/>
     <span class="form_error" ng-show="GOINPUTNAME[password].$error.server">{{ GOINPUTNAME[password].$error.server }}</span>
 </div>
 <div class="form_item_block">


### PR DESCRIPTION
When gocd has authentication enabled, these two fields are auto-populated
with the gocd username and password. As a result credentials can be
submitted that shouldn't be and a user's gocd account inadvertently
compromised.

<img width="374" alt="auto-populated" src="https://user-images.githubusercontent.com/452161/45106064-f7287c80-b0f2-11e8-8c39-1c5ffc3a6bc9.png">
