### PR TITLE
Update pom.xml to explicitly use commons-lang and a revised github api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>
-            <version>1.68</version>
+            <version>1.128</version>
         </dependency>
         <dependency>
             <groupId>org.gitlab4j</groupId>
@@ -86,6 +86,12 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+<!-- https://mvnrepository.com/artifact/commons-lang/commons-lang -->
+       <dependency>
+           <groupId>commons-lang</groupId>
+           <artifactId>commons-lang</artifactId>
+           <version>2.6</version>
+       </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-<!-- https://mvnrepository.com/artifact/commons-lang/commons-lang -->
+
        <dependency>
            <groupId>commons-lang</groupId>
            <artifactId>commons-lang</artifactId>


### PR DESCRIPTION
commons-lang has been deprecated and commons-lang3 is the latest. This commit explicitly pulls in commons-lang 2.6 which was the last in the earlier version. It is needed to build the plugin locally.

The earlier v 1.68 for github-api is no longer available, and referencing v 1.128 enables the plugin to be built.

This pull request doesn't yet migrate the plugin to use commons-lang3 (which I'm planning to raise as a separate PR).