### PR TITLE
Rename material and allow filtering out of draft pull requests

### DIFF
--- a/src/main/java/in/ashwanthkumar/gocd/github/provider/github/GitHubProvider.java
+++ b/src/main/java/in/ashwanthkumar/gocd/github/provider/github/GitHubProvider.java
@@ -38,7 +38,7 @@ public class GitHubProvider implements Provider {
 
     @Override
     public String getName() {
-        return "Github";
+        return "Github Pull Request";
     }
 
     @Override


### PR DESCRIPTION
Rename the Github material to make it clear that it relates to Github Pull Requests specifically.

- [X] https://github.com/ashwanthkumar/gocd-build-github-pull-requests/issues/146
- [ ] https://github.com/ashwanthkumar/gocd-build-github-pull-requests/issues/176